### PR TITLE
stickyForumHeader fix

### DIFF
--- a/bggUIC.user.styl
+++ b/bggUIC.user.styl
@@ -995,12 +995,12 @@ quoteTitleColor = headerColor
                 border-color buttonStdBgColor !important // c-i!
                 cc buttonStdBgColor
             .post-preview.bg-white
-                bg menu !important // c-i!
+                bg menu // c-i!
                 border menuBorder !important // c-i!
             if stickyForumHeader
                 .forum-header
                     height 97px
-                    position sticky
+                    position sticky !important
                     top 50px
                     width 100%
                     z-index 100

--- a/bggUIC.user.styl
+++ b/bggUIC.user.styl
@@ -995,7 +995,7 @@ quoteTitleColor = headerColor
                 border-color buttonStdBgColor !important // c-i!
                 cc buttonStdBgColor
             .post-preview.bg-white
-                bg menu // c-i!
+                bg menu !important // c-i!
                 border menuBorder !important // c-i!
             if stickyForumHeader
                 .forum-header


### PR DESCRIPTION
A fix to BGG overwriting current userstyle's stickyForumHeader rule with `.tw-relative {position: relative!important;}`